### PR TITLE
[Userhooks] Support for user info autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ autoprovisioning of the users based on OpenID claims received from the OP.
 
 # Getting started
 
-This application relies on a 3rd-party module for handling the communication
+This application relies on a 3rd-party module for handling of the communication
 between the RP and OP. For Apache webserver, we recommend installing the [mod_auth_openidc](https://github.com/zmartzone/mod_auth_openidc)
 module.
 
 The following Apache siteconfig settings will configure a special Location for handling
 user logins using the OIDC backend, the required special OIDC callback URI and OIDC coverage of
-Admin settings. Other locations are then covered by ownCloud session management. This
+Admin settings. Other locations are then covered by the ownCloud session management. This
 allows for multiple authentication methods to still be possible on your ownCloud
-instance (e.g. OAuth2 for sync clients, Apache baseauth). For a full module configuration
-documentation, please refer to the [wiki](https://github.com/zmartzone/mod_auth_openidc/wiki).
+instance (e.g. OAuth2 for sync clients, Apache baseauth). Please refer to the [wiki](https://github.com/zmartzone/mod_auth_openidc/wiki)
+for a full module configuration documentation.
 ```
 OIDCRedirectURI https://oidc.client.com/oidc_callback
 OIDCProviderMetadataURL https://oidc.provider.com/.well-known/openid-configuration

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ OIDC mapping to ownCloud and user backend settings could be configured from here
         * Logon only - this mode means that only existing ownCloud accounts can log in.
                         Assumes that user provisioning is done by another method (e.g. manual, LDAP, AD,...).
         * Provisioning - this mode autoprovisions new user accounts from provided OIDC claims on logon when necessary.
+* **Update user information on login** - if enabled, an user account will be updated with provided information (such as e-mail address, display name,...) when the user logs in using this app.
 
 ## Mapping configuration
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -17,21 +17,24 @@
      * @namespace OCA.UserOpenIDC.Admin
      */
     OCA.UserOpenIDC.Admin = {
-        validateClaim: function (claimName) {
-                var validClaims = ['claim_userid', 'claim_email', 'claim_displayname', 'claim_prefix'];
-                if ($.inArray(claimName, validClaims) > -1) {
+        validateSetting: function (settingName) {
+                var validSettings = [
+                        'claim_userid', 'claim_email', 'claim_displayname',
+                        'claim_prefix', 'backend_autoupdate'
+                ];
+                if ($.inArray(settingName, validSettings) > -1) {
                         return true;
                 } else {
                         return false;
                 }
         },
-        setOidcClaimMapping: function (name, value) {
+        setOidcSetting: function (name, value) {
                 OC.msg.startSaving('#user-openidc-save-indicator');
-                if (OCA.UserOpenIDC.Admin.validateClaim(name)) {
+                if (OCA.UserOpenIDC.Admin.validateSetting(name)) {
                         OC.AppConfig.setValue('user_openidc', name, value);
                         OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'success', data: {message: t('user_openidc', 'Saved')}});
                 } else {
-                        OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'error', data: {message: t('user_openidc', 'Unsupported claim')}});
+                        OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'error', data: {message: t('user_openidc', 'Unsupported setting')}});
                 }
         },
         setOidcClaimRequired: function (name) {
@@ -40,7 +43,7 @@
                 var cRequired = OC.AppConfig.getValue('user_openidc', 'backend_required_claims', 'claim_userid', function (value) {
                         var cRequiredArray = value.split(',');
                         var claimName = $('#user-openidc-save-indicator').data('save-set-claim-required');
-                        if ($.inArray(claimName, cRequiredArray) === -1 && OCA.UserOpenIDC.Admin.validateClaim(claimName)) {
+                        if ($.inArray(claimName, cRequiredArray) === -1 && OCA.UserOpenIDC.Admin.validateSetting(claimName)) {
                                 cRequiredArray.push(claimName);
                                 OC.AppConfig.setValue('user_openidc', 'backend_required_claims', cRequiredArray.join());
                                 $('#user-openidc-save-indicator').removeData('save-set-claim-required');
@@ -56,7 +59,7 @@
                 var cRequired = OC.AppConfig.getValue('user_openidc', 'backend_required_claims', 'claim_userid', function (value) {
                         var cRequiredArray = value.split(',');
                         var claimName = $('#user-openidc-save-indicator').data('save-unset-claim-required');
-                        if ($.inArray(claimName, cRequiredArray) !== -1 && OCA.UserOpenIDC.Admin.validateClaim(claimName)) {
+                        if ($.inArray(claimName, cRequiredArray) !== -1 && OCA.UserOpenIDC.Admin.validateSetting(claimName)) {
                                 cRequiredArray.splice($.inArray(claimName, cRequiredArray),1);
                                 OC.AppConfig.setValue('user_openidc', 'backend_required_claims', cRequiredArray.join());
                                 $('#user-openidc-save-indicator').removeData('save-unset-claim-required');
@@ -65,7 +68,6 @@
                                 OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'error', data: {message: t('user_openidc', 'Unsupported claim')}});
                         }
                 });
-
         }
     }
 })(OCA);
@@ -74,6 +76,7 @@ $(document).ready(function () {
         "use strict";
 
         $('input[type="checkbox"].user-openidc-required').change(function(e) {
+                e.preventDefault();
                 var el = $(this);
                 var name = el.attr('name');
                 if (el.is(':checked')) {
@@ -83,15 +86,29 @@ $(document).ready(function () {
                 }
 
         });
+
         $('.user-openidc-setting').change(function(e) {
+                e.preventDefault();
                 var el = $(this);
-                $.when(el.focusout()).then(function() {
-                        var name = $(this).attr('name');
-                        OCA.UserOpenIDC.Admin.setOidcClaimMapping(name, $(this).val());
-                });
-                if (e.keyCode === 13) {
-                        var name = $(this).attr('name');
-                        OCA.UserOpenIDC.Admin.setOidcClaimMapping(name, $(this).val());
+                var name = $(this).attr('name');
+                var type = $(this).attr('type');
+                if (type === 'checkbox') {
+                        if (el.is(':checked')) {
+                                OCA.UserOpenIDC.Admin.setOidcSetting(name, 'yes');
+                                return false;
+                        } else {
+                                OCA.UserOpenIDC.Admin.setOidcSetting(name, 'no');
+                                return false;
+                        }
+                } else {
+                        $.when(el.focusout()).then(function() {
+                                OCA.UserOpenIDC.Admin.setOidcSetting(name, $(this).val());
+                                return false;
+                        });
+                        if (e.keyCode === 13) {
+                                OCA.UserOpenIDC.Admin.setOidcSetting(name, $(this).val());
+                                return false;
+                        }
                 }
         });
 });

--- a/js/settings.js
+++ b/js/settings.js
@@ -45,6 +45,8 @@
                                 OC.AppConfig.setValue('user_openidc', 'backend_required_claims', cRequiredArray.join());
                                 $('#user-openidc-save-indicator').removeData('save-set-claim-required');
                                 OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'success', data: {message: t('user_openidc', 'Saved')}});
+                        } else {
+                                OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'error', data: {message: t('user_openidc', 'Unsupported claim')}});
                         }
                 });
         },
@@ -59,6 +61,8 @@
                                 OC.AppConfig.setValue('user_openidc', 'backend_required_claims', cRequiredArray.join());
                                 $('#user-openidc-save-indicator').removeData('save-unset-claim-required');
                                 OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'success', data: {message: t('user_openidc', 'Saved')}});
+                        } else {
+                                OC.msg.finishedSaving('#user-openidc-save-indicator', {status: 'error', data: {message: t('user_openidc', 'Unsupported claim')}});
                         }
                 });
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -64,6 +64,8 @@ class Application extends App {
 			'UserHooks', function ($c) {
 				return new UserHooks(
 					$c->query('AppName'),
+					$c->query('AppConfig'),
+					$c->query('Request'),
 					$c->query('AttributeMapper'),
 					$c->query('UserManager'),
 					$c->query('Logger')

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ namespace OCA\UserOpenIDC\AppInfo;
 use OCP\AppFramework\App;
 use OCA\UserOpenIDC\UserBackend;
 use OCA\UserOpenIDC\GroupBackend;
+use OCA\UserOpenIDC\Hooks\UserHooks;
 use OCA\UserOpenIDC\Controller\LoginController;
 use OCA\UserOpenIDC\Attributes\AttributeMapper;
 
@@ -60,6 +61,16 @@ class Application extends App {
 			}
 		);
 		$container->registerService(
+			'UserHooks', function ($c) {
+				return new UserHooks(
+					$c->query('AppName'),
+					$c->query('AttributeMapper'),
+					$c->query('UserManager'),
+					$c->query('Logger')
+				);
+			}
+		);
+		$container->registerService(
 			'GroupBackend', function ($c) {
 				return new GroupBackend(
 				);
@@ -94,12 +105,12 @@ class Application extends App {
 		);
 		$container->registerService(
 			'UserManager', function ($c) {
-				return \OC::$server->getUserManager();
+				return $c->query('ServerContainer')->getUserManager();
 			}
 		);
 		$container->registerService(
 			'GroupManager', function ($c) {
-				return \OC::$server->getGroupManager();
+				return $c->query('ServerContainer')->getGroupManager();
 			}
 		);
 		$container->registerService(

--- a/lib/Attributes/AttributeMapper.php
+++ b/lib/Attributes/AttributeMapper.php
@@ -117,7 +117,7 @@ class AttributeMapper {
 	 *
 	 * @return string e-mail address | null for invalid or missing address
 	 */
-	public function getEmail() {
+	public function getEMailAddress() {
 		$email = $this->getClaimValue('claim_email');
 		if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
 			return $email;

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -20,6 +20,7 @@ use \OCP\IUserSession;
 use \OCP\AppFramework\Controller;
 use \OCP\AppFramework\Http\RedirectResponse;
 use \OCP\AppFramework\Http\TemplateResponse;
+use \OCA\UserOpenIDC\Util;
 
 /**
  * LoginController class responsible for handling
@@ -98,26 +99,13 @@ class LoginController extends Controller {
 				}
 			}
 		} else {
-			if ($this->request->getCookie('mod_auth_openidc_session')) {
-				/**
-				 * Something went wrong on the OIDC Provider side
-				 * (e.g. the User didn't provide all the scopes required).
-				 * Let the User try again by removing the OIDC session cookie.
-				 * TODO: DI, like in the \OC\User\Session:unsetMagicInCookie
-				 */
-				$secureCookie = $this->request->getServerProtocol() === 'https';
-				unset($_COOKIE['mod_auth_openidc_session']);
-				\setcookie(
-					'mod_auth_openidc_session', '',
-					\time() - 3600, \OC::$WEBROOT, '',
-					$secureCookie, true
-				);
-				\setcookie(
-					'mod_auth_openidc_session', '',
-					\time() - 3600, \OC::$WEBROOT . '/', '',
-					$secureCookie, true
-				);
-			}
+			/**
+			 * Something went wrong on the OIDC Provider side
+			 * (e.g. the User didn't provide all the scopes required).
+			 * Let the User try again by removing the OIDC session cookie.
+			 */
+			Util::unsetOIDCSessionCookie($this->request);
+
 			$this->logger->error('OIDC login failed.', $this->logCtx);
 			return new TemplateResponse('', '403', array(), 'guest');
 		}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -58,7 +58,7 @@ class LoginController extends Controller {
 	/**
 	 * This method is associated with a route on which the OpenID Connect
 	 * protection must be enforced by Apache.
-	 * It initiates an internal login procedure and then, if succesfull,
+	 * It initiates an internal login procedure and then, if successfull,
 	 * redirects to the desired page. Call to $session->login() is
 	 * handled by this app's UserBackend 'checkPassword' method.
 	 *

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * ownCloud - user_openidc
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Miroslav Bauer, CESNET <bauer@cesnet.cz>
+ * @copyright Miroslav Bauer, CESNET 2018
+ * @license AGPL-3.0
+ */
+
+ namespace OCA\UserOpenIDC\Hooks;
+
+use OCP\IUser;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCA\UserOpenIDC\Attributes\AttributeMapper;
+
+/**
+ * @package OCA\UserOpenIDC\Hooks
+ */
+class UserHooks {
+
+	/** @var string **/
+	private $appName;
+	/** @var AttributeMapper */
+	private $attrMapper;
+	/** @var IUserManager */
+	private $userManager;
+	/** @var ILogger */
+	private $logger;
+	/** @var array */
+	private $logCtx;
+
+	/**
+	 * UserHooks constructor
+	 *
+	 * @param string $appName
+	 * @param AttributeMapper $attrMapper
+	 * @param IUserManager $userManager
+	 * @param ILogger $logger
+	 */
+	public function __construct($appName, AttributeMapper $attrMapper,
+		IUserManager $userManager, ILogger $logger
+	) {
+		$this->appName = $appName;
+		$this->attrMapper = $attrMapper;
+		$this->userManager = $userManager;
+		$this->logger = $logger;
+		$this->logCtx = array('app' => $this->appName);
+	}
+
+	/**
+	 * Connects all hooks to User specific events
+	 *
+	 * @return null
+	 */
+	public function connectHooks() {
+		$this->userManager->listen(
+			'\OC\User', 'postLogin', function ($user) {
+				$this->postLoginHook($user);
+			}
+		);
+		$this->userManager->listen(
+			'\OC\User', 'postCreateUser', function ($user, $password) {
+				$this->postCreateUserHook($user, $password);
+			}
+		);
+		$this->userManager->listen(
+			'\OC\User', 'postDelete', function ($user) {
+				$this->postDeleteHook($user);
+			}
+		);
+		$this->userManager->listen(
+			'\OC\User', 'logout', function () {
+				$this->logoutHook();
+			}
+		);
+	}
+	/**
+	 * Handles update of user attributes after login
+	 *
+	 * @param IUser $user
+	 *
+	 * @return null
+	 */
+	public function postLoginHook(IUser $user) {
+		$storedDn = $user->getDisplayName();
+		$actualDn = $this->attrMapper->getDisplayName();
+		$storedEMail = $user->getEMailAddress();
+		$actualEMail = $this->attrMapper->getEMailAddress();
+
+		if ($user) {
+			if ($actualDn && $storedDn !== $actualDn) {
+				$user->setDisplayName($actualDn);
+			}
+			if ($actualEMail && $storedEMail !== $actualEMail) {
+				$user->setEMailAddress($actualEMail);
+			}
+		}
+	}
+}

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -15,6 +15,7 @@
 use \OCP\IUser;
 use \OCP\ILogger;
 use \OCP\IRequest;
+use \OCP\IAppConfig;
 use \OCP\IUserManager;
 use \OCA\UserOpenIDC\Attributes\AttributeMapper;
 use \OCA\UserOpenIDC\Util;
@@ -26,6 +27,8 @@ class UserHooks {
 
 	/** @var string **/
 	private $appName;
+	/** @var IAppConfig **/
+	private $config;
 	/** @var IRequest **/
 	private $request;
 	/** @var AttributeMapper */
@@ -41,15 +44,17 @@ class UserHooks {
 	 * UserHooks constructor
 	 *
 	 * @param string $appName
+	 * @param IAppConfig $config
 	 * @param IRequest $request
 	 * @param AttributeMapper $attrMapper
 	 * @param IUserManager $userManager
 	 * @param ILogger $logger
 	 */
-	public function __construct($appName, IRequest $request,
+	public function __construct($appName, IAppConfig $config, IRequest $request,
 		AttributeMapper $attrMapper, IUserManager $userManager, ILogger $logger
 	) {
 		$this->appName = $appName;
+		$this->config = $config;
 		$this->request = $request;
 		$this->attrMapper = $attrMapper;
 		$this->userManager = $userManager;
@@ -92,6 +97,9 @@ class UserHooks {
 	 * @return null
 	 */
 	public function postLoginHook(IUser $user) {
+		if ($this->config->getValue($this->appName, 'backend_autoupdate', 'no') !== 'yes') {
+			return;
+		}
 		$storedDn = $user->getDisplayName();
 		$actualDn = $this->attrMapper->getDisplayName();
 		$storedEMail = $user->getEMailAddress();

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -12,10 +12,12 @@
 
  namespace OCA\UserOpenIDC\Hooks;
 
-use OCP\IUser;
-use OCP\ILogger;
-use OCP\IUserManager;
-use OCA\UserOpenIDC\Attributes\AttributeMapper;
+use \OCP\IUser;
+use \OCP\ILogger;
+use \OCP\IRequest;
+use \OCP\IUserManager;
+use \OCA\UserOpenIDC\Attributes\AttributeMapper;
+use \OCA\UserOpenIDC\Util;
 
 /**
  * @package OCA\UserOpenIDC\Hooks
@@ -24,6 +26,8 @@ class UserHooks {
 
 	/** @var string **/
 	private $appName;
+	/** @var IRequest **/
+	private $request;
 	/** @var AttributeMapper */
 	private $attrMapper;
 	/** @var IUserManager */
@@ -37,14 +41,16 @@ class UserHooks {
 	 * UserHooks constructor
 	 *
 	 * @param string $appName
+	 * @param IRequest $request
 	 * @param AttributeMapper $attrMapper
 	 * @param IUserManager $userManager
 	 * @param ILogger $logger
 	 */
-	public function __construct($appName, AttributeMapper $attrMapper,
-		IUserManager $userManager, ILogger $logger
+	public function __construct($appName, IRequest $request,
+		AttributeMapper $attrMapper, IUserManager $userManager, ILogger $logger
 	) {
 		$this->appName = $appName;
+		$this->request = $request;
 		$this->attrMapper = $attrMapper;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
@@ -99,5 +105,14 @@ class UserHooks {
 				$user->setEMailAddress($actualEMail);
 			}
 		}
+	}
+	/**
+	 * Destroys an OIDC session for the user if it exists and then
+	 * initiates a standard logout.
+	 *
+	 * @return null
+	 */
+	public function logoutHook() {
+		Util::unsetOIDCSessionCookie($this->request);
 	}
 }

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -74,16 +74,6 @@ class UserHooks {
 			}
 		);
 		$this->userManager->listen(
-			'\OC\User', 'postCreateUser', function ($user, $password) {
-				$this->postCreateUserHook($user, $password);
-			}
-		);
-		$this->userManager->listen(
-			'\OC\User', 'postDelete', function ($user) {
-				$this->postDeleteHook($user);
-			}
-		);
-		$this->userManager->listen(
 			'\OC\User', 'logout', function () {
 				$this->logoutHook();
 			}

--- a/lib/Settings/AdminPanel.php
+++ b/lib/Settings/AdminPanel.php
@@ -28,22 +28,22 @@ class AdminPanel implements ISettings {
 	/** @var IRequest */
 	private $request;
 	/** @var AppConfig */
-	private $appConfig;
+	private $config;
 	/** @var AttributeMapper */
 	private $attrMapper;
 
 	/**
 	 * AdminPanel constructor.
 	 *
-	 * @param AppConfig $appConfig
+	 * @param AppConfig $config
 	 * @param IRequest $request
 	 * @param AttributeMapper $attrMapper
 	 */
-	public function __construct(AppConfig $appConfig, IRequest $request,
+	public function __construct(AppConfig $config, IRequest $request,
 		AttributeMapper $attrMapper
 	) {
 		$this->appName = 'user_openidc';
-		$this->appConfig = $appConfig;
+		$this->config = $config;
 		$this->request = $request;
 		$this->attrMapper = $attrMapper;
 	}
@@ -69,8 +69,8 @@ class AdminPanel implements ISettings {
 	 * @return Template panel content
 	 */
 	public function getPanel() {
-		$t = new Template('user_openidc', 'settings-admin');
-		$backendMode = $this->appConfig->getValue($this->appName, 'backend_mode', 'inactive');
+		$backendMode = $this->config->getValue($this->appName, 'backend_mode', 'inactive');
+		$backendAutoupdate = $this->config->getValue($this->appName, 'backend_autoupdate', 'no');
 		$oidcPrefix = $this->attrMapper->getClaimPrefix();
 		$oidcClaims = array_filter(
 			$this->request->server,
@@ -84,7 +84,9 @@ class AdminPanel implements ISettings {
 		$claimEmail = $this->attrMapper->getClaimName('claim_email');
 		$requiredClaims = $this->attrMapper->getRequiredClaims();
 
+		$t = new Template('user_openidc', 'settings-admin');
 		$t->assign('backend_mode', $backendMode);
+		$t->assign('backend_autoupdate', $backendAutoupdate);
 		$t->assign('mapping_prefix', $oidcPrefix);
 		$t->assign('mapping_userid', $claimUserid);
 		$t->assign('mapping_dn', $claimDn);

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ownCloud - user_openidc
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Miroslav Bauer, CESNET <bauer@cesnet.cz>
+ * @copyright Miroslav Bauer, CESNET 2018
+ * @license AGPL-3.0
+ */
+
+namespace OCA\UserOpenIDC;
+
+use \OCP\IRequest;
+
+/**
+ * Helper function class
+ */
+class Util {
+
+	const OIDC_COOKIE_NAME = 'mod_auth_openidc_session';
+
+	/**
+	 * Invalidates and removes an OIDC session cookie if present.
+	 * TODO: DI, like in the \OC\User\Session:unsetMagicInCookie
+	 *
+	 * @param IRequest $request instance containing the cookie
+	 *
+	 * @return null;
+	 */
+	public static function unsetOIDCSessionCookie(IRequest $request) {
+		$cookieName = Util::OIDC_COOKIE_NAME;
+		if (in_array($cookieName, $_COOKIE)
+			&& $request->getCookie($cookieName)
+		) {
+			$secure = $request->getServerProtocol() === 'https';
+			unset($_COOKIE[$cookieName]);
+			\setcookie(
+				$cookieName, '',
+				\time() - 3600, \OC::$WEBROOT, '', $secure, true
+			);
+			\setcookie(
+				$cookieName, '', \time() - 3600,
+				\OC::$WEBROOT . '/', '', $secure, true
+			);
+		}
+	}
+}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -113,7 +113,7 @@ style('user_openidc', 'settings-admin');
 						</option>
 					<?php endforeach;?>
 				</select>
-				<input type="checkbox" class="user-openidc-required"
+				<input type="checkbox" class="checkbox user-openidc-required"
 					name="claim_displayname"
 					id="user-openidc-dn_required" value="0"
 <?php if (in_array('claim_displayname', $_['required_claims'])) {
@@ -141,7 +141,7 @@ style('user_openidc', 'settings-admin');
 						</option>
 				<?php endforeach;?>
 				</select>
-				<input type="checkbox" class="user-openidc-required"
+				<input type="checkbox" class="checkbox user-openidc-required"
 					name="claim_email"
 					id="user-openidc-email_required" value="0"
 <?php if (in_array('claim_email', $_['required_claims'])) {
@@ -160,6 +160,14 @@ style('user_openidc', 'settings-admin');
 
 		<div id="user-openidc-backend">
 			<h3><?php p($l->t('OpenID Connect backend configuration')) ?></h3>
+			<input type="checkbox" class="checkbox user-openidc-setting"
+				name="backend_autoupdate" id="user-openidc-autoupdate" value="1"
+				<?php if ($_['backend_autoupdate'] === 'yes')
+					print_unescaped('checked="checked"'); ?> >
+			</input>
+			<label for="user-openidc-autoupdate">
+				<?php p($l->t('Update user information on login')); ?>
+			</label>
 		</div>
 	</div>
 </div>

--- a/tests/unit/lib/Attributes/AttributeMapper.php
+++ b/tests/unit/lib/Attributes/AttributeMapper.php
@@ -184,9 +184,9 @@ class AttributeMapperTest extends TestCase {
 	 *
 	 * @return null
 	 */
-	public function testGetEmail($expected, $oidcClaims) {
+	public function testGetEMailAddress($expected, $oidcClaims) {
 		$this->request->server = $oidcClaims;
-		$actual = $this->attrMapper->getEmail();
+		$actual = $this->attrMapper->getEMailAddress();
 		$this->assertSame($expected, $actual);
 	}
 

--- a/tests/unit/lib/Hooks/UserHooks.php
+++ b/tests/unit/lib/Hooks/UserHooks.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * ownCloud - user_openidc
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Miroslav Bauer, CESNET <bauer@cesnet.cz>
+ * @copyright Miroslav Bauer, CESNET 2018
+ * @license AGPL-3.0
+ */
+
+namespace OCA\UserOpenIDC\Tests\Unit\Hooks;
+
+use \OCP\IUser;
+use \OCP\ILogger;
+use \OCP\IUserManager;
+use \Test\TestCase;
+use \OCA\UserOpenIDC\Attributes\AttributeMapper;
+use \OCA\UserOpenIDC\Hooks\UserHooks;
+
+/**
+ * Class UserHooksTest
+ *
+ * @package OCA\UserOpenIDC\Tests\Unit\Hooks
+ */
+class UserHooksTest extends TestCase {
+
+	/** @var ILogger | PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var AttributeMapper | \PHPUnit_Framework_MockObject_MockObject */
+	private $attrMapper;
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+	/** @var UserHooks | \PHPUnit_Framework_MockObject_MockObject */
+	private $userHooks;
+
+	/**
+	 * @return null
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->logger = $this->createMock(ILogger::class);
+		$this->attrMapper = $this->createMock(AttributeMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->user->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('John Doe');
+		$this->user->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('user0@nomail.com');
+		$this->userHooks = new UserHooks(
+			'user_openidc',
+			$this->attrMapper,
+			$this->userManager,
+			$this->logger
+		);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginHookWillUpdateDisplayNameIfChanged() {
+		$expected = 'Joe Doe';
+		$this->attrMapper->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Joe Doe');
+		$this->user->expects($this->once())
+			->method('setDisplayName')
+			->with($expected);
+		$this->userHooks->postLoginHook($this->user);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginHookWontUpdateDisplayNameIfNotChanged() {
+		$this->attrMapper->expects($this->once())
+			->method('getDisplayName')
+			->willReturn($this->user->getDisplayName());
+		$this->user->expects($this->never())
+			->method('setDisplayName');
+		$this->userHooks->postLoginHook($this->user);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginWontSetDisplayNameToNull() {
+		$this->attrMapper->expects($this->once())
+			->method('getDisplayName')
+			->willReturn(null);
+		$this->user->expects($this->never())->method('setDisplayName');
+		$this->userHooks->postLoginHook($this->user);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginHookWillUpdateEmailIfChanged() {
+		$expected = 'user0@mail.com';
+		$this->attrMapper->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn($expected);
+		$this->user->expects($this->once())
+			->method('setEMailAddress')
+			->with($expected);
+		$this->userHooks->postLoginHook($this->user);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginHookWontUpdateEmailIfNotChanged() {
+		$this->attrMapper->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn($this->user->getEMailAddress());
+		$this->user->expects($this->never())
+			->method('setEMailAddress');
+		$this->userHooks->postLoginHook($this->user);
+	}
+	/**
+	 * @return null
+	 */
+	public function testPostLoginHookWontSetEmailToNull() {
+		$this->attrMapper->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn(null);
+		$this->user->expects($this->never())->method('setEMailAddress');
+		$this->userHooks->postLoginHook($this->user);
+	}
+}

--- a/tests/unit/lib/Hooks/UserHooks.php
+++ b/tests/unit/lib/Hooks/UserHooks.php
@@ -14,10 +14,12 @@ namespace OCA\UserOpenIDC\Tests\Unit\Hooks;
 
 use \OCP\IUser;
 use \OCP\ILogger;
+use \OCP\IRequest;
 use \OCP\IUserManager;
 use \Test\TestCase;
 use \OCA\UserOpenIDC\Attributes\AttributeMapper;
 use \OCA\UserOpenIDC\Hooks\UserHooks;
+use \OCA\UserOpenIDC\Util;
 
 /**
  * Class UserHooksTest
@@ -28,6 +30,8 @@ class UserHooksTest extends TestCase {
 
 	/** @var ILogger | PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
+	/** @var IRequest | PHPUnit_Framework_MockObject_MockObject */
+	private $request;
 	/** @var AttributeMapper | \PHPUnit_Framework_MockObject_MockObject */
 	private $attrMapper;
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
@@ -44,6 +48,10 @@ class UserHooksTest extends TestCase {
 		parent::setUp();
 
 		$this->logger = $this->createMock(ILogger::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->request->expects($this->any())
+			->method('getServerProtocol')
+			->willReturn(true);
 		$this->attrMapper = $this->createMock(AttributeMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->user = $this->createMock(IUser::class);
@@ -55,6 +63,7 @@ class UserHooksTest extends TestCase {
 			->willReturn('user0@nomail.com');
 		$this->userHooks = new UserHooks(
 			'user_openidc',
+			$this->request,
 			$this->attrMapper,
 			$this->userManager,
 			$this->logger


### PR DESCRIPTION
This adds a basic optional user info autoupdate functionality. When enabled in the Admin settings, **email** and **displayname** will be updated after every user's login using this app.

It also invalidates user's OIDC session on logout from ownCloud.
_This could be also optional in the future (maybe as a user preference)_
